### PR TITLE
Set error detail only for WebApplicationExceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ hs_err_pid*
 .settings
 .project
 .classpath
+/rest-jersey-utils.iml

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+
+lombok.addLombokGeneratedAnnotation = true

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.9</version>
+				<version>0.8.0</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>
@@ -216,7 +216,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.10</version>
+			<version>1.16.14</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper.java
@@ -20,17 +20,22 @@ public class RFCExceptionMapper implements ExceptionMapper<Exception> {
 	public Response toResponse(@NonNull Exception exception) {
 		ResponseBuilder builder;
 		StatusType statusInfo;
+
+		final String exceptionMessage;
+
 		if (exception instanceof WebApplicationException) {
 			Response response = ((WebApplicationException) exception).getResponse();
 			builder = Response.fromResponse(response);
 			statusInfo = response.getStatusInfo();
+			exceptionMessage = exception.getMessage();
 		} else {
 			builder = Response.serverError();
 			statusInfo = Status.INTERNAL_SERVER_ERROR;
+			exceptionMessage = null;
 		}
 
 		SimpleExceptionJson simpleExceptionJson = new SimpleExceptionJson(statusInfo.getReasonPhrase(),
-				statusInfo.getStatusCode(), exception.getMessage());
+				statusInfo.getStatusCode(), exceptionMessage);
 		builder.entity(simpleExceptionJson);
 		builder.type("application/problem+json");
 

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/SimpleExceptionJson.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/SimpleExceptionJson.java
@@ -4,10 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.ToString;
 
 @Getter
 @AllArgsConstructor
 @EqualsAndHashCode
+@ToString
 public class SimpleExceptionJson {
 	@NonNull
 	String title;

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
@@ -1,7 +1,6 @@
 package com.mercateo.rest.jersey.utils.exception;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ServiceUnavailableException;
@@ -53,6 +52,15 @@ public class RFCExceptionMapper0Test {
 	public void testToResponseNull() throws Exception {
 		Response r = uut.toResponse(new NullPointerException());
 		assertEquals(500, r.getStatus());
+		assertEquals(new SimpleExceptionJson("Internal Server Error", 500, null), r.getEntity());
+	}
+
+	@Test
+	public void testToResponseNoExceptionMessageIfNotWebAppException() throws Exception {
+		// an exception with some sensitive data :D
+		Response r = uut.toResponse(new IllegalArgumentException("Password x3$5oz#DD8 too short!"));
+		assertEquals(500, r.getStatus());
+		// detail should not contain exception message, but be null
 		assertEquals(new SimpleExceptionJson("Internal Server Error", 500, null), r.getEntity());
 	}
 


### PR DESCRIPTION
Do not set the error detail with the exception message for ordinary
exceptions.

The exception message is now only set to the error detail field if
the exception is a WebApplicationException.

Also fixed:
- Ignore IntelliJ project file in git
- Added @ToString annotation to SimpleExceptionJson in order to see a better error message when tests are failing 