### PR TITLE
add allow OPTIONS-requests filter

### DIFF
--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/CORSFeature.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/CORSFeature.java
@@ -45,6 +45,13 @@ public class CORSFeature implements Feature {
 			context.register(simpleAccessControlAllowHeaderFilter);
 			modified = true;
 		}
+
+		OptionsRequestFilter optionsRequestFilter = new OptionsRequestFilter();
+		if (!context.getConfiguration().isRegistered(optionsRequestFilter)) {
+			context.register(optionsRequestFilter);
+			modified = true;
+		}
+
 		return modified;
 	}
 

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/OptionsRequestFilter.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/OptionsRequestFilter.java
@@ -1,0 +1,33 @@
+package com.mercateo.rest.jersey.utils.cors;
+
+import java.io.IOException;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import lombok.EqualsAndHashCode;
+
+@Provider
+@PreMatching
+@EqualsAndHashCode
+/**
+ * This filter allows OPTIONS-requests ignoring any other request filters.
+ */
+public class OptionsRequestFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext context) throws IOException {
+        // allow all OPTIONS-requests independent of the requested resource
+        Request request = context.getRequest();
+        if (request != null && HttpMethod.OPTIONS.equals(request.getMethod())) {
+
+            // send a "200 - OK" back to the browser
+            context.abortWith(Response.ok().build());
+        }
+    }
+}

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/OptionsRequestFilterIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/OptionsRequestFilterIntegrationTest.java
@@ -1,0 +1,58 @@
+package com.mercateo.rest.jersey.utils.cors;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+public class OptionsRequestFilterIntegrationTest extends JerseyTest {
+    @Path("/")
+    public static final class TestResource {
+        @GET
+        public void TestException() {
+
+        }
+    }
+
+    @Override
+    protected Application configure() {
+        ResourceConfig rs = new ResourceConfig(TestResource.class, JacksonFeature.class);
+
+        rs.register(new ContainerRequestFilter() {
+
+            @Override
+            public void filter(ContainerRequestContext requestContext) throws IOException {
+                // this simulates an authorization filter, that denies access to
+                // the TestResource
+                throw new WebApplicationException(Status.UNAUTHORIZED);
+            }
+        });
+
+        rs.register(new OptionsRequestFilter());
+        return rs;
+    }
+
+    @Test
+    public void optionsOnTest() {
+        // GET should not be allowed
+        int statusGet = target("/").request().get().getStatus();
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), statusGet);
+
+        // OPTIONS should be allowed
+        int statusOptions = target("/").request().options().getStatus();
+        assertEquals(Response.Status.OK.getStatusCode(), statusOptions);
+    }
+}


### PR DESCRIPTION
Browsers typically send pre-flight requests using the OPTIONS-HTTP-method. I would therefore suggest to allow this kind of request by default.