### PR TITLE
listen to Throwable in RFCExceptionMapper

### DIFF
--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper.java
@@ -29,10 +29,10 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Provider
-public class RFCExceptionMapper implements ExceptionMapper<Exception> {
+public class RFCExceptionMapper implements ExceptionMapper<Throwable> {
 
 	@Override
-	public Response toResponse(@NonNull Exception exception) {
+	public Response toResponse(@NonNull Throwable exception) {
 		ResponseBuilder builder;
 		StatusType statusInfo;
 

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
@@ -55,6 +55,13 @@ public class RFCExceptionMapper0Test {
 		assertEquals(new SimpleExceptionJson("Internal Server Error", 500, null), r.getEntity());
 	}
 
+    @Test
+    public void testToResponseWithThrowable() throws Exception {
+        Response r = uut.toResponse(new OutOfMemoryError());
+        assertEquals(500, r.getStatus());
+        assertEquals(new SimpleExceptionJson("Internal Server Error", 500, null), r.getEntity());
+    }
+
 	@Test
 	public void testToResponseNoExceptionMessageIfNotWebAppException() throws Exception {
 		// an exception with some sensitive data :D

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapperIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapperIntegrationTest.java
@@ -1,9 +1,11 @@
 package com.mercateo.rest.jersey.utils.exception;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 
@@ -24,6 +26,12 @@ public class RFCExceptionMapperIntegrationTest extends JerseyTest {
 		public void TestException() {
 			throw new BadRequestException("hello");
 		}
+
+	    @GET
+	    @Path("/throwable")
+	    public void TestThrowable() {
+	        throw new OutOfMemoryError("crashed");
+	    }
 	}
 
 	@Data
@@ -53,5 +61,19 @@ public class RFCExceptionMapperIntegrationTest extends JerseyTest {
 		}
 		Assert.fail();
 	}
+
+    @Test
+    public void throwableTest() {
+        try {
+            target("/throwable").request().get(String.class);
+        } catch (InternalServerErrorException e) {
+            SimpleExceptionJson se = e.getResponse().readEntity(SimpleExceptionJson.class);
+            assertEquals("Internal Server Error", se.getTitle());
+            assertEquals(500, se.getStatus());
+            assertNull(se.getDetail());
+            return;
+        }
+        Assert.fail();
+    }
 
 }


### PR DESCRIPTION
This is necessary for preventing internal throwable messages being sent to the client.