### PR TITLE
add pattern field to output the regex pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ hs_err_pid*
 /rest-jersey-utils.iml
 
 .idea
+.factorypath

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationError.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationError.java
@@ -15,6 +15,8 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 
@@ -25,16 +27,14 @@ import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-
-import lombok.ToString;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @AllArgsConstructor
@@ -51,38 +51,68 @@ public class ValidationError {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     Integer limit;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String pattern;
+
+    public ValidationError(@NonNull String code, @NonNull String path, @NonNull Integer limit) {
+        this.code = code;
+        this.path = path;
+        this.limit = limit;
+    }
+
+    public ValidationError(@NonNull String code, @NonNull String path, @NonNull String pattern) {
+        this.code = code;
+        this.path = path;
+        this.pattern = pattern;
+    }
+
     public static ValidationError of(ConstraintViolation<?> constraintViolation) {
         Annotation annotation = constraintViolation.getConstraintDescriptor().getAnnotation();
         String path = constructJsonPath(constraintViolation.getPropertyPath());
         ValidationError error = null;
 
-        if (annotation instanceof NotNull || annotation.annotationType().getSimpleName().equals("NotBlank") || annotation instanceof AssertTrue) {
+        if (annotation instanceof NotNull || annotation.annotationType().getSimpleName().equals(
+                "NotBlank") || annotation instanceof AssertTrue) {
             return new ValidationError(ValidationErrorCode.REQUIRED.name(), path);
         } else if (annotation instanceof Size) {
             final Size sizeAnnotation = (Size) annotation;
             final Object value = constraintViolation.getInvalidValue();
 
             if (value instanceof String && value.toString().length() < sizeAnnotation.min()) {
-                error = new ValidationError(ValidationErrorCode.MINLENGTH.name(), path, sizeAnnotation.min());
-            } else if (value instanceof String && value.toString().length() > sizeAnnotation.max()) {
-                error = new ValidationError(ValidationErrorCode.MAXLENGTH.name(), path, sizeAnnotation.max());
-            } else if (value instanceof Collection && ((Collection<?>) value).size() < sizeAnnotation.min()) {
-                error = new ValidationError(ValidationErrorCode.MINITEMS.name(), path, sizeAnnotation.min());
-            } else if (value instanceof Collection && ((Collection<?>) value).size() > sizeAnnotation.max()) {
-                error = new ValidationError(ValidationErrorCode.MAXITEMS.name(), path, sizeAnnotation.max());
+                error = new ValidationError(ValidationErrorCode.MINLENGTH.name(), path,
+                        sizeAnnotation.min());
+            } else if (value instanceof String && value.toString().length() > sizeAnnotation
+                    .max()) {
+                error = new ValidationError(ValidationErrorCode.MAXLENGTH.name(), path,
+                        sizeAnnotation.max());
+            } else if (value instanceof Collection && ((Collection<?>) value)
+                    .size() < sizeAnnotation.min()) {
+                error = new ValidationError(ValidationErrorCode.MINITEMS.name(), path,
+                        sizeAnnotation.min());
+            } else if (value instanceof Collection && ((Collection<?>) value)
+                    .size() > sizeAnnotation.max()) {
+                error = new ValidationError(ValidationErrorCode.MAXITEMS.name(), path,
+                        sizeAnnotation.max());
             }
         } else if (annotation instanceof Min) {
             final Min min = (Min) annotation;
-            error = new ValidationError(ValidationErrorCode.MINLENGTH.name(), path, ((int) min.value()));
+            error = new ValidationError(ValidationErrorCode.MINLENGTH.name(), path, ((int) min
+                    .value()));
         } else if (annotation instanceof Max) {
             Max max = (Max) annotation;
-            error = new ValidationError(ValidationErrorCode.MAXLENGTH.name(), path, ((int) max.value()));
+            error = new ValidationError(ValidationErrorCode.MAXLENGTH.name(), path, ((int) max
+                    .value()));
         } else if (annotation.annotationType().getSimpleName().equals("Email")) {
             error = new ValidationError(ValidationErrorCode.INVALID_EMAIL.name(), path);
+        } else if (annotation instanceof Pattern) {
+            final Pattern pattern = (Pattern) annotation;
+            error = new ValidationError(ValidationErrorCode.PATTERN.name(), path, pattern
+                    .regexp());
         } else {
-            String code = constraintViolation.getMessage() != null && !constraintViolation.getMessage().isEmpty()
-                    ? constraintViolation.getMessage()
-                    : ValidationErrorCode.UNKNOWN.name();
+            String code = constraintViolation.getMessage() != null && !constraintViolation
+                    .getMessage().isEmpty()
+                            ? constraintViolation.getMessage()
+                            : ValidationErrorCode.UNKNOWN.name();
             error = new ValidationError(code, path);
         }
         return error;

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationError.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationError.java
@@ -66,6 +66,7 @@ public class ValidationError {
         this.pattern = pattern;
     }
 
+    @SuppressWarnings("boxing")
     public static ValidationError of(ConstraintViolation<?> constraintViolation) {
         Annotation annotation = constraintViolation.getConstraintDescriptor().getAnnotation();
         String path = constructJsonPath(constraintViolation.getPropertyPath());

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/ValidationErrorTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/ValidationErrorTest.java
@@ -1,0 +1,101 @@
+package com.mercateo.rest.jersey.utils.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ValidationErrorTest {
+
+    private Validator validator;
+
+    @Before
+    public void setUp() throws Exception {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void testInvalidPattern() {
+
+        // given
+        ClassInvalidIban classInvalidIban = new ClassInvalidIban();
+
+        // when
+        Set<ConstraintViolation<Object>> violations = validator.validate(classInvalidIban);
+        ValidationError validationError = ValidationError.of(violations.iterator().next());
+
+        // then
+        assertThat(validationError.getCode()).isEqualTo(ValidationErrorCode.PATTERN.name());
+        assertThat(validationError.getPath()).isEqualTo("#/iban");
+        assertThat(validationError.getPattern()).isEqualTo(
+                "^[A-Z]{2}[0-9]{2}(?:[ ]?[0-9]{4}){4}(?!(?:[ ]?[0-9]){3})(?:[ ]?[0-9]{1,2})?$");
+
+    }
+
+    @Test
+    public void testInvalidMaxLength() {
+
+        // given
+        ClassInvalidMaxLength classInvalidMaxLength = new ClassInvalidMaxLength();
+
+        // when
+        Set<ConstraintViolation<Object>> violations = validator.validate(classInvalidMaxLength);
+        ValidationError validationError = ValidationError.of(violations.iterator().next());
+
+        // then
+        assertThat(validationError.getCode()).isEqualTo(ValidationErrorCode.MAXLENGTH.name());
+        assertThat(validationError.getPath()).isEqualTo("#/longString");
+        assertThat(validationError.getLimit()).isEqualTo(9);
+
+    }
+
+    @Test
+    public void testInvalidMinLength() {
+
+        // given
+        ClassInvalidMinLength classInvalidMinLength = new ClassInvalidMinLength();
+
+        // when
+        Set<ConstraintViolation<Object>> violations = validator.validate(classInvalidMinLength);
+        ValidationError validationError = ValidationError.of(violations.iterator().next());
+
+        // then
+        assertThat(validationError.getCode()).isEqualTo(ValidationErrorCode.MINLENGTH.name());
+        assertThat(validationError.getPath()).isEqualTo("#/shortString");
+        assertThat(validationError.getLimit()).isEqualTo(4);
+
+    }
+
+    private static class ClassInvalidMaxLength {
+
+        @Max(9)
+        private final String longString = "longString";
+
+    }
+
+    private static class ClassInvalidMinLength {
+
+        @Min(4)
+        private final String shortString = "short";
+
+    }
+
+    private static class ClassInvalidIban {
+
+        @Pattern(regexp = "^[A-Z]{2}[0-9]{2}(?:[ ]?[0-9]{4}){4}(?!(?:[ ]?[0-9]){3})(?:[ ]?[0-9]{1,2})?$")
+        private final String iban = "DEX0111122223333444455";
+
+    }
+
+}


### PR DESCRIPTION
Now, the specified regex in the `@Pattern` annotation exists in the exception output, for example:

```
class ExampleJson {
    @NotNull
    @Pattern(regexp = "^[A-Z]{2}[0-9]{2}(?:[ ]?[0-9]{4}){4}(?!(?:[ ]?[0-9]){3})(?:[ ]?[0-9]{1,2})?$")
    private final String iban;
}
```

Exception
```
{
  "type": "https://**********/errors/invalid",
  "status": 400,
  "title": "Invalid",
  "detail": "The request body is syntactically correct, but is not accepted, because of its data.",
  "errors": [
    {
      "code": "PATTERN",
      "path": "#/iban",
      "pattern": "^[A-Z]{2}[0-9]{2}(?:[ ]?[0-9]{4}){4}(?!(?:[ ]?[0-9]){3})(?:[ ]?[0-9]{1,2})?$"
    }
  ]
}
```