### PR TITLE
issue-13: update documenation link of custom invalid errors

### DIFF
--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionMapper.java
@@ -34,10 +34,10 @@ public class ConstraintViolationExceptionMapper implements ExceptionMapper<Const
     public Response toResponse(ConstraintViolationException violationException) {
         List<ValidationError> errors = toValidationErrors(violationException);
 
-        log.error("Sending error response to client {}", errors);
+        log.debug("Sending error response to client {}", errors);
 
         ValidationExceptionJson entity = new ValidationExceptionJson(
-                "https://unite.eu/developers/errors/invalid",
+                "http://developers.unite.eu/errors/invalid",
                 "Invalid",
                 BAD_REQUEST.getStatusCode(),
                 "The request body is syntactically correct, but is not accepted, because of its data.",


### PR DESCRIPTION
Consciously, I didn't create a test of the used URL, because you have to look into the response content to detect an error when Cloudfront is used (such as 404). There isn't an error response header and we got 200 even if the page doesn't exists. 