### PR TITLE
pr-15: use new com.mercateo.oss.parent.pom; fix license headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>com.mercateo.oss.parent</groupId>
+		<groupId>com.mercateo.oss</groupId>
 		<artifactId>oss-parent-pom</artifactId>
-		<version>0.9.0</version>
+		<version>1.0.6</version>
 	</parent>
 
 	<artifactId>rest-jersey-utils</artifactId>

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginRequestFilter.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginRequestFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginResponseFilter.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginResponseFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/CORSFeature.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/CORSFeature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/OriginFilter.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/OriginFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/OriginFilterForFrontend.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/OriginFilterForFrontend.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/SimpleAccessControlAllowHeaderFilter.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/SimpleAccessControlAllowHeaderFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/SimpleExceptionJson.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/SimpleExceptionJson.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationError.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationErrorCode.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationErrorCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationExceptionJson.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationExceptionJson.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResource.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceWithGenericId.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceWithGenericId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/listing/IdParameterBean.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/listing/IdParameterBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/listing/IdProvider.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/listing/IdProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/listing/SearchQueryParameterBean.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/listing/SearchQueryParameterBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/validation/EnumValue.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/validation/EnumValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/validation/EnumValueValidator.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/validation/EnumValueValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlank.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlank.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankValidator.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginRequestFilterIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginRequestFilterIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.cors;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginResponseFilterIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginResponseFilterIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.cors;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/CorsFeatureIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/CorsFeatureIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.cors;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/OriginFilterForFrontend0Test.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/OriginFilterForFrontend0Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.cors;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/OriginFilterTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/OriginFilterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.cors;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/SimpleAccessControlAllowHeaderFilterIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/SimpleAccessControlAllowHeaderFilterIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.cors;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionMapperTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionMapperTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.exception;
 
 import com.mercateo.rest.jersey.utils.validation.EnumValue;

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.exception;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapperIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapperIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.exception;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.listing;
 
 import org.assertj.core.api.Assertions;

--- a/src/test/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceWithGenericIdTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceWithGenericIdTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.listing;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/mercateo/rest/jersey/utils/listing/SearchQueryParameterBean0Test.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/listing/SearchQueryParameterBean0Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.listing;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/mercateo/rest/jersey/utils/listing/TestBinder.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/listing/TestBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.listing;
 
 import java.lang.reflect.Field;

--- a/src/test/java/com/mercateo/rest/jersey/utils/validation/EnumValueTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/validation/EnumValueTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.validation;
 
 import lombok.val;

--- a/src/test/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.validation;
 
 import lombok.AllArgsConstructor;

--- a/src/test/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankValidatorTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankValidatorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.jersey.utils.validation;
 
 import lombok.val;


### PR DESCRIPTION
As figured out in @uweschaefer [comment](https://github.com/Mercateo/rest-jersey-utils/pull/12#discussion_r244802230), the current configuration of the maven license plugin doesn't consider the tests files.

Because the latest version of [oss-parent-pom](https://github.com/Mercateo/oss-parent-pom) include already this configuration, we should use this.