### PR TITLE
Bundle all provided ExceptionMappers in Feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_install:
   - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
@@ -14,7 +14,7 @@ deploy:
     on:
       repo: Mercateo/rest-jersey-utils
       branch: master
-      jdk: oraclejdk8
+      jdk: openjdk8
   -
     provider: script
     script: .travis/deploy.sh
@@ -22,4 +22,4 @@ deploy:
     on:
       repo: Mercateo/rest-jersey-utils
       tags: true
-      jdk: oraclejdk8
+      jdk: openjdk8

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<artifactId>rest-jersey-utils</artifactId>
 	<groupId>com.mercateo.rest</groupId>
-	<version>0.1.8-SNAPSHOT</version>
+	<version>0.1.10-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>rest-jersey-utils</name>
 	<description>Some untility classes for Jersey</description>

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ExceptionMapperFeature.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ExceptionMapperFeature.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mercateo.rest.jersey.utils.exception;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+public class ExceptionMapperFeature implements Feature {
+
+    @Override
+    public boolean configure(FeatureContext context) {
+
+        context.register(RFCExceptionMapper.class);
+        context.register(ConstraintViolationExceptionMapper.class);
+        context.register(JsonMappingExceptionMapper.class, 1);
+        context.register(ParamExceptionMapper.class);
+        context.register(PathIdMismatchExceptionMapper.class);
+        context.register(DuplicateExceptionMapper.class);
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
This makes it possible to register all mappers at once in applications
that use rest-jersey-utils.