### PR TITLE
Update dependencies & plugins for Java 17 & SpringBoot 3.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,4 @@ A package for useful java classes for jersey, including:
 * REST Resource for listings  
 * ConstraintViolationExceptionMapper for Validation errors.
 
-Make sure you have implementation for ```javax.el-api 3.0.0```, for that, 
-the following dependency can be used :
-
-```
-<dependency>
-    <groupId>org.glassfish</groupId>
-    <artifactId>javax.el</artifactId>
-   <version>3.0.0</version>
-</dependency>
-```
+Make sure you have implementation for ```jakarta.el-api```

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.2</version>
+			<version>5.9.3</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,19 +48,6 @@
 		<jersey.version>3.1.2</jersey.version>
 		<glassfish.version>3.0.4</glassfish.version>
 	</properties>
-	<developers>
-		<developer>
-			<id>joerg_adler</id>
-			<name>Joerg Adler</name>
-			<email>joerg.adler@mercateo.com</email>
-			<url>http://www.mercateo.com</url>
-			<organization>Mercateo AG</organization>
-			<organizationUrl>http://www.mercateo.com</organizationUrl>
-			<roles>
-				<role>developer</role>
-			</roles>
-		</developer>
-	</developers>
 	<build>
 		<plugins>
 			<plugin>
@@ -294,6 +281,12 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>3.24.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava-testlib</artifactId>
+			<version>23.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,15 +4,15 @@
 	<parent>
 		<groupId>com.mercateo.oss</groupId>
 		<artifactId>oss-parent-pom</artifactId>
-		<version>1.0.6</version>
+		<version>1.0.9</version>
 	</parent>
 
 	<artifactId>rest-jersey-utils</artifactId>
 	<groupId>com.mercateo.rest</groupId>
-	<version>0.2.2-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>rest-jersey-utils</name>
-	<description>Some untility classes for Jersey</description>
+	<description>Some utility classes for Jersey</description>
 	<url>https://github.com/Mercateo/rest-jersey-utils</url>
 	<inceptionYear>2017</inceptionYear>
 	<organization>
@@ -43,8 +43,10 @@
 	</scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jackson.version>2.11.1</jackson.version>
-		<jmh.version>1.18</jmh.version>
+		<jackson.version>2.15.2</jackson.version>
+		<jmh.version>1.36</jmh.version>
+		<jersey.version>3.1.2</jersey.version>
+		<glassfish.version>3.0.4</glassfish.version>
 	</properties>
 	<developers>
 		<developer>
@@ -63,13 +65,18 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.1.2</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.3</version>
+				<version>3.0.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.8</version>
+				<version>1.6.13</version>
 				<extensions>true</extensions>
 				<configuration>
 					<serverId>ossrh</serverId>
@@ -80,11 +87,9 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>3.11.0</version>
 				<configuration>
-					<compilerVersion>1.8</compilerVersion>
-					<source>1.8</source>
-					<target>1.8</target>
+					<release>17</release>
 					<debug>true</debug>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>
@@ -96,7 +101,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -109,7 +114,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.4</version>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -122,7 +127,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.2</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -134,7 +139,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.0</version>
+				<version>0.8.10</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>
@@ -156,14 +161,9 @@
 			<dependency>
 				<groupId>org.glassfish.jersey</groupId>
 				<artifactId>jersey-bom</artifactId>
-				<version>2.23.1</version>
+				<version>${jersey.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.jersey.media</groupId>
-				<artifactId>jersey-media-json-jackson</artifactId>
-				<version>2.31</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -176,101 +176,130 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>5.3.5.Final</version>
+			<version>8.0.1.Final</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/javax.el/javax.el-api -->
 		<dependency>
-			<groupId>javax.el</groupId>
-			<artifactId>javax.el-api</artifactId>
-			<version>3.0.0</version>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.0.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.testng</groupId>
+					<artifactId>testng</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.el</groupId>
+			<artifactId>jakarta.el-api</artifactId>
+			<version>5.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
-			<version>3.0.0</version>
+			<artifactId>jakarta.el</artifactId>
+			<version>5.0.0-M1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20170516</version>
+			<version>20230618</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.hk2</groupId>
+			<artifactId>hk2</artifactId>
+			<version>${glassfish.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.inject</groupId>
+			<artifactId>jersey-hk2</artifactId>
+			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<artifactId>jersey-test-framework-provider-inmemory</artifactId>
 			<groupId>org.glassfish.jersey.test-framework.providers</groupId>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<artifactId>javax.inject</artifactId>
-					<groupId>org.glassfish.hk2.external</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-server</artifactId>
 			<exclusions>
 				<exclusion>
-					<artifactId>javax.inject</artifactId>
 					<groupId>org.glassfish.hk2.external</groupId>
+					<artifactId>jakarta.inject</artifactId>
 				</exclusion>
 				<exclusion>
-					<artifactId>aopalliance-repackaged</artifactId>
 					<groupId>org.glassfish.hk2.external</groupId>
+					<artifactId>aopalliance-repackaged</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-json-jackson</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
+			<version>2.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.14</version>
+			<version>1.18.28</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>1.10.19</version>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>5.4.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.tngtech.junit.dataprovider</groupId>
+			<artifactId>junit-jupiter-params-dataprovider</artifactId>
+			<version>2.10</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.9.2</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava-testlib</artifactId>
-			<version>23.0</version>
-			<scope>test</scope>
+			<groupId>jakarta.activation</groupId>
+			<artifactId>jakarta.activation-api</artifactId>
+			<version>2.1.2</version>
 		</dependency>
 		<dependency>
-			<groupId>com.tngtech.java</groupId>
-			<artifactId>junit-dataprovider</artifactId>
-			<version>1.10.2</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.inject</groupId>
-			<artifactId>javax.inject</artifactId>
-			<version>1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish.jersey.media</groupId>
-			<artifactId>jersey-media-json-jackson</artifactId>
-			<scope>test</scope>
+			<groupId>jakarta.inject</groupId>
+			<artifactId>jakarta.inject-api</artifactId>
+			<version>2.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.mercateo</groupId>
 			<artifactId>common.rest.schemagen</artifactId>
-			<version>0.19.0</version>
+			<version>0.21.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.8.0</version>
+			<version>3.24.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.4.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -287,7 +316,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.6</version>
+						<version>3.1.0</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginRequestFilter.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginRequestFilter.java
@@ -17,12 +17,11 @@ package com.mercateo.rest.jersey.utils.cors;
 
 import java.io.IOException;
 
-import javax.annotation.Priority;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.Priorities;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginResponseFilter.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginResponseFilter.java
@@ -17,12 +17,11 @@ package com.mercateo.rest.jersey.utils.cors;
 
 import java.io.IOException;
 
-import javax.annotation.Priority;
-import javax.ws.rs.Priorities;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/AccessControlMaxAgeHeaderFilter.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/AccessControlMaxAgeHeaderFilter.java
@@ -17,13 +17,12 @@ package com.mercateo.rest.jersey.utils.cors;
 
 import java.io.IOException;
 
-import javax.annotation.Priority;
-import javax.ws.rs.Priorities;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.MultivaluedMap;
-
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/CORSFeature.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/CORSFeature.java
@@ -18,9 +18,8 @@ package com.mercateo.rest.jersey.utils.cors;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.core.Feature;
-import javax.ws.rs.core.FeatureContext;
-
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.FeatureContext;
 import lombok.NonNull;
 
 public class CORSFeature implements Feature {

--- a/src/main/java/com/mercateo/rest/jersey/utils/cors/SimpleAccessControlAllowHeaderFilter.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/cors/SimpleAccessControlAllowHeaderFilter.java
@@ -19,13 +19,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Priority;
-import javax.ws.rs.Priorities;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.MultivaluedMap;
-
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionMapper.java
@@ -15,19 +15,18 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
 import com.mercateo.rest.jersey.utils.listing.SearchQueryParameterBean;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionType.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionType.java
@@ -15,7 +15,7 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 import lombok.Getter;
 

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/DuplicateException.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/DuplicateException.java
@@ -15,8 +15,7 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import javax.validation.ValidationException;
-
+import jakarta.validation.ValidationException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/DuplicateExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/DuplicateExceptionMapper.java
@@ -15,15 +15,14 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 import java.util.Arrays;
 import java.util.List;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ExceptionMapperFeature.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ExceptionMapperFeature.java
@@ -15,8 +15,8 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import javax.ws.rs.core.Feature;
-import javax.ws.rs.core.FeatureContext;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.FeatureContext;
 
 public class ExceptionMapperFeature implements Feature {
 

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/JsonMappingExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/JsonMappingExceptionMapper.java
@@ -15,7 +15,7 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -24,12 +24,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonMappingException.Reference;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
 
 public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
 

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ParamExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ParamExceptionMapper.java
@@ -15,16 +15,16 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 import java.util.Arrays;
 import java.util.List;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-
 import org.glassfish.jersey.server.ParamException;
 import org.glassfish.jersey.server.ParamException.QueryParamException;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
 
 public class ParamExceptionMapper implements ExceptionMapper<ParamException> {
 

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/PathIdMismatchException.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/PathIdMismatchException.java
@@ -15,7 +15,7 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import javax.validation.ValidationException;
+import jakarta.validation.ValidationException;
 
 public class PathIdMismatchException extends ValidationException {
 

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/PathIdMismatchExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/PathIdMismatchExceptionMapper.java
@@ -15,15 +15,14 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 import java.util.Arrays;
 import java.util.List;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper.java
@@ -15,15 +15,14 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.Response.Status.Family;
-import javax.ws.rs.core.Response.StatusType;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response.Status.Family;
+import jakarta.ws.rs.core.Response.StatusType;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationError.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/exception/ValidationError.java
@@ -18,18 +18,17 @@ package com.mercateo.rest.jersey.utils.exception;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ElementKind;
-import javax.validation.Path;
-import javax.validation.constraints.AssertTrue;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ElementKind;
+import jakarta.validation.Path;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;

--- a/src/main/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceWithGenericId.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceWithGenericId.java
@@ -21,17 +21,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.MediaType;
-
 import com.google.common.collect.Lists;
 import com.mercateo.common.rest.schemagen.JerseyResource;
 import com.mercateo.common.rest.schemagen.JsonHyperSchema;
@@ -44,6 +33,16 @@ import com.mercateo.common.rest.schemagen.link.relation.Relation;
 import com.mercateo.common.rest.schemagen.types.ObjectWithSchema;
 import com.mercateo.common.rest.schemagen.types.PaginatedResponse;
 
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.MediaType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;

--- a/src/main/java/com/mercateo/rest/jersey/utils/listing/IdParameterBean.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/listing/IdParameterBean.java
@@ -15,8 +15,7 @@
  */
 package com.mercateo.rest.jersey.utils.listing;
 
-import javax.ws.rs.PathParam;
-
+import jakarta.ws.rs.PathParam;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/mercateo/rest/jersey/utils/listing/SearchQueryParameterBean.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/listing/SearchQueryParameterBean.java
@@ -19,10 +19,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.mercateo.common.rest.schemagen.IgnoreInRestSchema;
 
-import javax.validation.constraints.Min;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.QueryParam;
-
+import jakarta.validation.constraints.Min;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.QueryParam;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/com/mercateo/rest/jersey/utils/validation/EnumValue.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/validation/EnumValue.java
@@ -17,8 +17,8 @@ package com.mercateo.rest.jersey.utils.validation;
 
 import java.lang.annotation.*;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 @Documented
 @Target({ElementType.FIELD})

--- a/src/main/java/com/mercateo/rest/jersey/utils/validation/EnumValueValidator.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/validation/EnumValueValidator.java
@@ -19,8 +19,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 public class EnumValueValidator implements ConstraintValidator<EnumValue, CharSequence> {
 

--- a/src/main/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlank.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlank.java
@@ -17,8 +17,8 @@ package com.mercateo.rest.jersey.utils.validation;
 
 import java.lang.annotation.*;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 @Target( {ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankValidator.java
+++ b/src/main/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankValidator.java
@@ -15,9 +15,8 @@
  */
 package com.mercateo.rest.jersey.utils.validation;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginRequestFilterIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginRequestFilterIntegrationTest.java
@@ -15,23 +15,24 @@
  */
 package com.mercateo.rest.jersey.utils.cors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Response;
-
-import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.util.JacksonFeature;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Response;
 
 public class AccessControlAllowOriginRequestFilterIntegrationTest extends JerseyTest {
 	private static boolean requestGoneThrough = false;

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginResponseFilterIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlAllowOriginResponseFilterIntegrationTest.java
@@ -15,22 +15,22 @@
  */
 package com.mercateo.rest.jersey.utils.cors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Response;
-
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Response;
 
 public class AccessControlAllowOriginResponseFilterIntegrationTest extends JerseyTest {
 

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlMaxAgeHeaderFilterIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlMaxAgeHeaderFilterIntegrationTest.java
@@ -15,17 +15,17 @@
  */
 package com.mercateo.rest.jersey.utils.cors;
 
-import static org.junit.Assert.assertEquals;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.MultivaluedMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 public class AccessControlMaxAgeHeaderFilterIntegrationTest extends JerseyTest {
 	@Path("/")

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlMaxAgeHeaderFilterIntegrationTest2.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/AccessControlMaxAgeHeaderFilterIntegrationTest2.java
@@ -15,17 +15,17 @@
  */
 package com.mercateo.rest.jersey.utils.cors;
 
-import static org.junit.Assert.assertNull;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.MultivaluedMap;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 public class AccessControlMaxAgeHeaderFilterIntegrationTest2 extends JerseyTest {
 	@Path("/")

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/CorsFeatureIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/CorsFeatureIntegrationTest.java
@@ -15,24 +15,23 @@
  */
 package com.mercateo.rest.jersey.utils.cors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import java.util.List;
 
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import jersey.repackaged.com.google.common.collect.Lists;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import lombok.SneakyThrows;
 
 public class CorsFeatureIntegrationTest extends JerseyTest {
@@ -52,7 +51,7 @@ public class CorsFeatureIntegrationTest extends JerseyTest {
 		ResourceConfig rs = new ResourceConfig(TestResource.class, JacksonFeature.class);
 
 		CORSFeature corsFeature = new CORSFeature(new OriginFilter.Default(
-				Lists.newArrayList(new URL("http://localhost:8080")), Lists.newArrayList("0.0.0.0")));
+				List.of(new URL("http://localhost:8080")), List.of("0.0.0.0")));
 		rs.register(corsFeature);
 		return rs;
 	}

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/OriginFilterForFrontend0Test.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/OriginFilterForFrontend0Test.java
@@ -15,19 +15,16 @@
  */
 package com.mercateo.rest.jersey.utils.cors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
-@RunWith(DataProviderRunner.class)
 @SuppressWarnings("boxing")
 public class OriginFilterForFrontend0Test {
 
@@ -89,7 +86,7 @@ public class OriginFilterForFrontend0Test {
 		};
 	}
 
-	@Test
+	@ParameterizedTest
 	@UseDataProvider("data")
 	public void testIsOriginAllowed(String domain, String origin, boolean expected) {
 

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/OriginFilterTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/OriginFilterTest.java
@@ -15,22 +15,21 @@
  */
 package com.mercateo.rest.jersey.utils.cors;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
+import java.util.List;
 
-import org.junit.Test;
-
-import jersey.repackaged.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
 
 public class OriginFilterTest {
 
 	@Test
 	public void testIsOriginAllowedString() throws Exception {
 
-		OriginFilter originFilter = new OriginFilter.Default(Lists.newArrayList(new URL("http://localhost:8080")),
-				Lists.newArrayList("0.0.0.0"));
+		OriginFilter originFilter = new OriginFilter.Default(List.of(new URL("http://localhost:8080")),
+				List.of("0.0.0.0"));
 		assertTrue(originFilter.isOriginAllowed("http://localhost:8080"));
 		assertTrue(originFilter.isOriginAllowed("http://0.0.0.0:8080"));
 
@@ -40,8 +39,8 @@ public class OriginFilterTest {
 
 	@Test
 	public void testIsOriginAllowedURL() throws Exception {
-		OriginFilter originFilter = new OriginFilter.Default(Lists.newArrayList(new URL("http://localhost:8080")),
-				Lists.newArrayList("0.0.0.0"));
+		OriginFilter originFilter = new OriginFilter.Default(List.of(new URL("http://localhost:8080")),
+				List.of("0.0.0.0"));
 		assertTrue(originFilter.isOriginAllowed(new URL("http://localhost:8080")));
 		assertTrue(originFilter.isOriginAllowed(new URL("http://0.0.0.0:8080")));
 

--- a/src/test/java/com/mercateo/rest/jersey/utils/cors/SimpleAccessControlAllowHeaderFilterIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/cors/SimpleAccessControlAllowHeaderFilterIntegrationTest.java
@@ -15,17 +15,17 @@
  */
 package com.mercateo.rest.jersey.utils.cors;
 
-import static org.junit.Assert.assertEquals;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.MultivaluedMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 public class SimpleAccessControlAllowHeaderFilterIntegrationTest extends JerseyTest {
 	@Path("/")

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionMapperTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionMapperTest.java
@@ -21,35 +21,34 @@ import static org.mockito.Mockito.when;
 
 import java.lang.annotation.Annotation;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Path;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-import javax.validation.metadata.ConstraintDescriptor;
-import javax.ws.rs.core.Response;
-
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotBlank;
 import org.json.JSONObject;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.Sets;
 import com.mercateo.rest.jersey.utils.listing.SearchQueryParameterBean;
 import com.mercateo.rest.jersey.utils.validation.EnumValue;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.metadata.ConstraintDescriptor;
+import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ConstraintViolationExceptionMapperTest {
 
     private final static int MIN_VAL = 2;
@@ -60,7 +59,7 @@ public class ConstraintViolationExceptionMapperTest {
 
     private static Validator validator;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionTypeTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/ConstraintViolationExceptionTypeTest.java
@@ -15,11 +15,10 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConstraintViolationExceptionTypeTest {
 

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/DuplicateExceptionMapperTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/DuplicateExceptionMapperTest.java
@@ -17,11 +17,11 @@ package com.mercateo.rest.jersey.utils.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.ws.rs.core.Response;
-
 import org.assertj.core.api.Assertions;
 import org.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.core.Response;
 
 public class DuplicateExceptionMapperTest {
 

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/JsonMappingExceptionMapperTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/JsonMappingExceptionMapperTest.java
@@ -26,22 +26,21 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import javax.ws.rs.core.Response;
-
 import org.assertj.core.api.Assertions;
 import org.json.JSONObject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonMappingException.Reference;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
+
+import jakarta.ws.rs.core.Response;
 
 @SuppressWarnings("boxing")
-@RunWith(DataProviderRunner.class)
+//@RunWith(DataProviderRunner.class)
 public class JsonMappingExceptionMapperTest {
 
     private JsonMappingExceptionMapper uut = new JsonMappingExceptionMapper();
@@ -213,7 +212,7 @@ public class JsonMappingExceptionMapperTest {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("fieldsForMappingTest")
     public void test_mappableFields(Class<?> targetType, boolean customError) throws Throwable {
 

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/JsonMappingExceptionMapperTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/JsonMappingExceptionMapperTest.java
@@ -40,7 +40,6 @@ import com.tngtech.junit.dataprovider.UseDataProvider;
 import jakarta.ws.rs.core.Response;
 
 @SuppressWarnings("boxing")
-//@RunWith(DataProviderRunner.class)
 public class JsonMappingExceptionMapperTest {
 
     private JsonMappingExceptionMapper uut = new JsonMappingExceptionMapper();

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/ParamExceptionMapperTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/ParamExceptionMapperTest.java
@@ -17,13 +17,13 @@ package com.mercateo.rest.jersey.utils.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.ws.rs.core.Response;
-
 import org.glassfish.jersey.server.ParamException.PathParamException;
 import org.glassfish.jersey.server.ParamException.QueryParamException;
 import org.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+
+import jakarta.ws.rs.core.Response;
 
 public class ParamExceptionMapperTest {
 

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/PathIdMismatchExceptionMapperTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/PathIdMismatchExceptionMapperTest.java
@@ -17,11 +17,11 @@ package com.mercateo.rest.jersey.utils.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.ws.rs.core.Response;
-
 import org.assertj.core.api.Assertions;
 import org.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.core.Response;
 
 public class PathIdMismatchExceptionMapperTest {
 

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
@@ -16,12 +16,11 @@
 package com.mercateo.rest.jersey.utils.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.assertj.core.api.Assertions;
+import com.google.common.testing.NullPointerTester;
 import org.junit.jupiter.api.Test;
 
-// 
-// import com.google.common.testing.NullPointerTester;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.core.Response;
@@ -30,22 +29,22 @@ public class RFCExceptionMapper0Test {
 
 	RFCExceptionMapper uut = new RFCExceptionMapper();
 
-//	@Test
-//	public void testNullContracts() throws Exception {
-//		NullPointerTester nullPointerTester = new NullPointerTester();
-//		Class<?> clazz = uut.getClass();
-//
-//		nullPointerTester.testAllPublicConstructors(clazz);
-//		nullPointerTester.testAllPublicStaticMethods(clazz);
-//
-//		nullPointerTester.testInstanceMethods(uut, NullPointerTester.Visibility.PROTECTED);
-//		nullPointerTester.testStaticMethods(clazz, NullPointerTester.Visibility.PROTECTED);
-//	}
+	@Test
+	public void testNullContracts() throws Exception {
+		NullPointerTester nullPointerTester = new NullPointerTester();
+		Class<?> clazz = uut.getClass();
+
+		nullPointerTester.testAllPublicConstructors(clazz);
+		nullPointerTester.testAllPublicStaticMethods(clazz);
+
+		nullPointerTester.testInstanceMethods(uut, NullPointerTester.Visibility.PROTECTED);
+		nullPointerTester.testStaticMethods(clazz, NullPointerTester.Visibility.PROTECTED);
+	}
 
 	@Test
 	public void testContentTypeHeader() throws Exception{
 		Response r = uut.toResponse(new BadRequestException());
-		Assertions.assertThat(r.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
+		assertThat(r.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
 	}
 
 	@Test

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
@@ -15,32 +15,32 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import static org.junit.Assert.assertEquals;
-
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.ServiceUnavailableException;
-import javax.ws.rs.core.Response;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import com.google.common.testing.NullPointerTester;
+// 
+// import com.google.common.testing.NullPointerTester;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ServiceUnavailableException;
+import jakarta.ws.rs.core.Response;
 
 public class RFCExceptionMapper0Test {
 
 	RFCExceptionMapper uut = new RFCExceptionMapper();
 
-	@Test
-	public void testNullContracts() throws Exception {
-		NullPointerTester nullPointerTester = new NullPointerTester();
-		Class<?> clazz = uut.getClass();
-
-		nullPointerTester.testAllPublicConstructors(clazz);
-		nullPointerTester.testAllPublicStaticMethods(clazz);
-
-		nullPointerTester.testInstanceMethods(uut, NullPointerTester.Visibility.PROTECTED);
-		nullPointerTester.testStaticMethods(clazz, NullPointerTester.Visibility.PROTECTED);
-	}
+//	@Test
+//	public void testNullContracts() throws Exception {
+//		NullPointerTester nullPointerTester = new NullPointerTester();
+//		Class<?> clazz = uut.getClass();
+//
+//		nullPointerTester.testAllPublicConstructors(clazz);
+//		nullPointerTester.testAllPublicStaticMethods(clazz);
+//
+//		nullPointerTester.testInstanceMethods(uut, NullPointerTester.Visibility.PROTECTED);
+//		nullPointerTester.testStaticMethods(clazz, NullPointerTester.Visibility.PROTECTED);
+//	}
 
 	@Test
 	public void testContentTypeHeader() throws Exception{

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapper0Test.java
@@ -15,11 +15,12 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 import com.google.common.testing.NullPointerTester;
-import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ServiceUnavailableException;

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapperIntegrationTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/RFCExceptionMapperIntegrationTest.java
@@ -15,21 +15,20 @@
  */
 package com.mercateo.rest.jersey.utils.exception;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.GET;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Application;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -74,7 +73,7 @@ public class RFCExceptionMapperIntegrationTest extends JerseyTest {
 			assertEquals("hello", se.getDetail());
 			return;
 		}
-		Assert.fail();
+		fail();
 	}
 
     @Test
@@ -88,7 +87,7 @@ public class RFCExceptionMapperIntegrationTest extends JerseyTest {
             assertNull(se.getDetail());
             return;
         }
-        Assert.fail();
+		fail();
     }
 
 }

--- a/src/test/java/com/mercateo/rest/jersey/utils/exception/ValidationErrorTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/exception/ValidationErrorTest.java
@@ -21,26 +21,25 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Valid;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Pattern;
-
 import org.hibernate.validator.constraints.NotBlank;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Valid;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 
 public class ValidationErrorTest {
 
     private Validator validator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();

--- a/src/test/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceTest.java
@@ -16,7 +16,7 @@
 package com.mercateo.rest.jersey.utils.listing;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import lombok.NonNull;
 

--- a/src/test/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceWithGenericIdTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/listing/AbstractListingResourceWithGenericIdTest.java
@@ -15,22 +15,23 @@
  */
 package com.mercateo.rest.jersey.utils.listing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.UUID;
 
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Application;
-
 import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJsonProvider;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
-import org.junit.Test;
+import org.glassfish.jersey.test.inmemory.InMemoryTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -42,6 +43,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.mercateo.common.rest.schemagen.link.LinkMetaFactory;
 import com.mercateo.common.rest.schemagen.link.injection.LinkFactoryResourceConfig;
 
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
 import lombok.Data;
 import lombok.NonNull;
 
@@ -108,7 +112,7 @@ public class AbstractListingResourceWithGenericIdTest extends JerseyTest {
 
         ResourceConfig rs = new ResourceConfig();
         rs.register(TestBinder.forAllMocksOf(this));
-        rs.register(JacksonJaxbJsonProvider.class);
+        rs.register(JacksonJsonProvider.class);
         rs.register(TestResource.class);
         rs.property(ServerProperties.BV_SEND_ERROR_IN_RESPONSE, Boolean.TRUE);
         LinkFactoryResourceConfig.configure(rs);
@@ -130,16 +134,20 @@ public class AbstractListingResourceWithGenericIdTest extends JerseyTest {
         assertEquals(UUID_3, testJson.getId());
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void testSummary_invalidId() {
-        TestJson testJson = target("test/notValidId/summary").request().get(TestJson.class);
-        assertEquals(UUID_2, testJson.getId());
+        assertThrows(BadRequestException.class, () -> {
+            TestJson testJson = target("test/notValidId/summary").request().get(TestJson.class);
+            assertEquals(UUID_2, testJson.getId());
+        });
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void testGet_invalidId() {
-        TestJson testJson = target("test/notValidId").request().get(TestJson.class);
-        assertEquals(UUID_3, testJson.getId());
+        assertThrows(BadRequestException.class, () -> {
+            TestJson testJson = target("test/notValidId").request().get(TestJson.class);
+            assertEquals(UUID_3, testJson.getId());
+        });
     }
 
     @Test

--- a/src/test/java/com/mercateo/rest/jersey/utils/listing/SearchQueryParameterBean0Test.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/listing/SearchQueryParameterBean0Test.java
@@ -15,9 +15,10 @@
  */
 package com.mercateo.rest.jersey.utils.listing;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SearchQueryParameterBean0Test {
     @Test
@@ -36,17 +37,17 @@ public class SearchQueryParameterBean0Test {
     }
 
     @SuppressWarnings("unused")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_exceptionWithNegativeOffset() {
         // no setting of default value needed
-        SearchQueryParameterBean searchQueryParameterBean = new SearchQueryParameterBean(-1, 0);
+        assertThrows(IllegalArgumentException.class, () -> new SearchQueryParameterBean(-1, 0));
     }
 
     @SuppressWarnings("unused")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_exceptionWithNegativeLimit() {
         // no setting of default value needed
-        SearchQueryParameterBean searchQueryParameterBean = new SearchQueryParameterBean(0, -1);
+        assertThrows(IllegalArgumentException.class, () -> new SearchQueryParameterBean(-1, 0));
     }
 
 }

--- a/src/test/java/com/mercateo/rest/jersey/utils/validation/EnumValueTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/validation/EnumValueTest.java
@@ -15,22 +15,21 @@
  */
 package com.mercateo.rest.jersey.utils.validation;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import lombok.val;
 
 public class EnumValueTest {
 
     private Validator validator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();

--- a/src/test/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankTest.java
@@ -17,13 +17,12 @@ package com.mercateo.rest.jersey.utils.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import lombok.AllArgsConstructor;
 import lombok.val;
 
@@ -31,7 +30,7 @@ public class NullOrNotBlankTest {
 
     private Validator validator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();

--- a/src/test/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankValidatorTest.java
+++ b/src/test/java/com/mercateo/rest/jersey/utils/validation/NullOrNotBlankValidatorTest.java
@@ -16,7 +16,7 @@
 package com.mercateo.rest.jersey.utils.validation;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import lombok.val;
 


### PR DESCRIPTION
Changes:

- Parent POM: com.mercateo.oss.oss-parent-pom 1.0.6 > 1.0.9
- maven-compiler changed to Java 17 <release>
- release-sign-artifict pluging maven-gpg-plugin updated 1.6 > 3.1.0

Dependency updates:

- POM Properties:
	- Updated jackson.version: 2.11.1 > 2.15.2
	- Updated jmh.version: 1.18 > 1.36
	- Added jersey.version: 3.1.2
	- Added glassfish.version: 3.0.4

- Dependencies:
	- Added:
		- maven-surefire-plugin: 3.1.2
		- jakarta.validation-api: 3.0.2
		- (jakarta.el.)jakarta.el-api: 5.0.1
		- (org.glassfish.)jakarta.el: 5.0.0-M4
		- (org.glassfish.hk2.)hk2: 3.0.4 (glassfish.version)
		- (org.glassfish.jersey.inject.)jersey-hk2: 3.0.4 (jersey.version)
		- jackson-annotations: 2.15.2 (jackson.version)
		- mockito-junit-jupiter: 5.4.0
		- junit-jupiter-engine: 5.9.2
		- jakarta.activation-api: 2.1.2
		- jakarta.inject-api: 2.0.1
		- logback-classic: 1.4.8
	- Removed:
		- (javax.el.)javax.el: 3.0.0
		- (org.glassfish)javax.el: 3.0.0
		- mockito-core: 1.10.19
		- guava-testlib: 23.0
		- (com.tngtech.java.)junit-data-provider: 1.10.2
		- javax.inject: 1
	- Updated
		- maven-release-plugin 2.5.3 > 3.0.1
		- nexus-staging-maven-plugin: 1.6.8 > 1.6.13
		- maven-compiler-plugin: 3.6.1 > 3.11.0
		- maven-source-plugin: 3.0.1 > 3.3.0
		- maven-javadoc-plugin: 2.10.4 > 3.5.0
		- maven-jar-plugin: 3.0.2 > 3.3.0
		- jacoco-maven-plugin: 0.8.0 > 0.8.10
		- hibernate-validation: 5.3.5.Final > 8.0.1.Final
		- (org.json.)json: 20170516 > 20230618
		- jersey-media-json-jackson: 2.31 > 3.1.2 (jersey.version)
		- slf4j: 1.7.25 > 2.0.7
		- lombok: 1.16.14 > 1.18.28
		- (com.tngtech.junit.dataprovider.)junit-jupiter-params-dataprovider: 2.10
		- jersey-media-json-jackson: 2.23.1 > 3.1.2
		- (com.mercateo.)common.rest.schemagen: 0.19.0 > 0.21.0
		- assertj-core: 3.24.2 > 3.8.0